### PR TITLE
Fix memory leak in Draw3DClusterer

### DIFF
--- a/Core/drawUtils.cpp
+++ b/Core/drawUtils.cpp
@@ -1021,6 +1021,10 @@ void Draw3DClusterer(GLWidget *glw, Clusterer *clusterer)
         printf("done.\n");
         fflush(stdout);
     }
+
+    delete [] minVals;
+    delete [] maxVals;
+    delete [] values;
 }
 
 struct Streamline


### PR DESCRIPTION
The same arrays are allocated in `Draw3DClassifier` and free'd there, but in `Draw3DClusterer` they are leaked.